### PR TITLE
'Updated' container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL \
   org.opencontainers.image.vendor="https://peterevans.dev" \
   org.opencontainers.image.licenses="MIT"
 
-ENV OSRM_VERSION 5.22.0
+ENV OSRM_VERSION 5.26.0
 
 # Let the container know that there is no TTY
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ RUN mkdir /osrm-src \
  && cp -r /osrm-src/osrm-backend-$OSRM_VERSION/profiles/* /osrm-profiles \
  && rm -rf /osrm-src
 
+# allows for adding prebuilt files to the image for faster use in dev without egress charges
+# expects data in same format as on gs, so prebuilt/$OSRM_DATA_LABEL/*.osrm*
+COPY prebuilt/ /prebuilt/
+
 # Set the entrypoint
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN apt-get -y update \
     pkg-config \
     gcc \
     python-dev \
+    python-pip \
     python-setuptools \    
  && apt-get clean \
- && easy_install -U pip \
  && pip install -U crcmod \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/* /var/tmp/*

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ trap _sig SIGKILL SIGTERM SIGHUP SIGINT EXIT
 if [ "$OSRM_MODE" == "CREATE" ]; then
     
     # Retrieve the PBF file
-    curl -L $OSRM_PBF_URL --create-dirs -o $OSRM_DATA_PATH/$OSRM_DATA_LABEL.osm.pbf
+    curl -k -L $OSRM_PBF_URL --create-dirs -o $OSRM_DATA_PATH/$OSRM_DATA_LABEL.osm.pbf
     
     # Build the graph
     osrm-extract $OSRM_DATA_PATH/$OSRM_DATA_LABEL.osm.pbf -p /osrm-profiles/$OSRM_GRAPH_PROFILE.lua

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,8 +45,13 @@ if [ "$OSRM_MODE" == "CREATE" ]; then
     fi
     
 else
-
-    if [ ! -z "$OSRM_SA_KEY_PATH" ] && [ ! -z "$OSRM_PROJECT_ID" ] && [ ! -z "$OSRM_GS_BUCKET" ]; then
+    if  [ -d /prebuilt ] && [ -d /prebuilt/$OSRM_DATA_LABEL ] ; then 
+        cd $OSRM_DATA_PATH || exit
+        for i in /prebuilt/"$OSRM_DATA_LABEL"/*; do
+            echo ln -s "$i"
+            ln -s "$i" .
+        done
+    elif [ -n "$OSRM_SA_KEY_PATH" ] && [ -n "$OSRM_PROJECT_ID" ] && [ -n "$OSRM_GS_BUCKET" ]; then
 
         # Activate the service account to access storage
         gcloud auth activate-service-account --key-file $OSRM_SA_KEY_PATH


### PR DESCRIPTION
Hi, 

commit 15a037f988e720d946e6749b55084488e9b98b  and 10ee3c659b6fa22fcf112e8abdd2326dda83ee9a should be reasonable enough (ignoring that Python 2 is rather deprecated)

but worse, was no longer able to download directly from geofabrik due to SSL certs

So much more controversial would be commit 670a273abc732c07acf8b29ea9d28773c544f990, bit most likely that needs to be fixed in image `peterevans/xenial-gcloud:1.2.23`?

I can live with `-k` in this case, but its not exactly optimal